### PR TITLE
Replace invalid links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ['https://afdian.net/@sheep_realms']
+custom: ['https://afdian.com/a/sheep_realms']

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@
 - [B站](https://space.bilibili.com/43881503)
 
 ## 赞助
-- [爱发电](https://afdian.net/@sheep_realms)
+- [爱发电](https://afdian.com/a/sheep_realms)
 
 </details>


### PR DESCRIPTION
The domain afdian.net is unavailable now, maybe we need to replace it by afdian.com instead